### PR TITLE
feat: add Giveaway action and modal to user actions

### DIFF
--- a/src/lib/components/ui/useractions/ActionsButtonModal.svelte
+++ b/src/lib/components/ui/useractions/ActionsButtonModal.svelte
@@ -6,6 +6,7 @@
   import UpdateDot from "../updatedot/UpdateDot.svelte";
   import ChangelogModal from "./actions/ChangelogModal.svelte";
   import ChatPollModal from "./actions/ChatPollModal.svelte";
+  import GiveawayModal from "./actions/GiveawayModal.svelte";
 
   interface Props {
     showModal: boolean;
@@ -23,6 +24,10 @@
 
   function handleStartPoll() {
     action = ActionType.ChatPoll;
+  }
+
+  function handleStartGiveaway() {
+    action = ActionType.Giveaway;
   }
 </script>
 
@@ -43,6 +48,10 @@
         <Button variant="secondary" onclick={handleStartPoll}>
           Start Poll
         </Button>
+
+        <Button variant="secondary" onclick={handleStartGiveaway}>
+          Start Giveaway
+        </Button>
       {/if}
     </div>
   {/snippet}
@@ -52,4 +61,6 @@
   <ChangelogModal bind:action />
 {:else if action === ActionType.ChatPoll}
   <ChatPollModal bind:action />
+{:else if action === ActionType.Giveaway}
+  <GiveawayModal bind:action />
 {/if}

--- a/src/lib/components/ui/useractions/actions/GiveawayModal.svelte
+++ b/src/lib/components/ui/useractions/actions/GiveawayModal.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+  import { fanslyApi } from "@/lib/api/fansly.svelte";
+  import { formatZodErrorMessage } from "@/lib/helpers";
+  import { sharedState } from "@/lib/state/state.svelte";
+  import { ActionType } from "@/lib/types";
+  import type { ZodIssue } from "zod";
+  import { z, ZodError } from "zod";
+  import Button from "../../button/button.svelte";
+  import Input from "../../input/input.svelte";
+  import Label from "../../label/label.svelte";
+  import Modal from "../../modal/Modal.svelte";
+
+  interface Props {
+    action: ActionType;
+  }
+
+  let { action = $bindable() }: Props = $props();
+
+  let keyword: string = $state("");
+  let time: number = $state(1);
+  let subluck: number = $state(1);
+  let validtionErrors: ZodError<any> | null = $state(null);
+
+  const Giveaway = z.object({
+    keyword: z
+      .string()
+      .max(256)
+      .min(1)
+      .regex(/^[a-zA-Z0-9]+$/, "Must be 1 word"),
+    Time: z.number().int().positive().max(60),
+    Subluck: z.number().int().positive().max(100),
+  });
+
+  function onClose() {
+    action = ActionType.None;
+  }
+
+  async function onCreateGiveaway() {
+    try {
+      const giveaway = Giveaway.parse({
+        keyword: keyword,
+        Time: time,
+        Subluck: subluck,
+      });
+      validtionErrors = null;
+
+      const result = await fanslyApi.sendChatMessage(
+        sharedState.chatroomId!,
+        `!giveaway start ${giveaway.keyword} ${giveaway.Time} ${giveaway.Subluck}`,
+      );
+      if (!result) {
+        validtionErrors = new ZodError([
+          {
+            message: "Failed to create giveaway, please try again later.",
+            path: ["sendChatMessage"],
+          } as ZodIssue,
+        ]);
+        return;
+      }
+
+      onClose();
+    } catch (error: any) {
+      validtionErrors = error as ZodError<typeof Giveaway>;
+    }
+  }
+</script>
+
+<Modal showModal={true} {onClose}>
+  {#snippet header()}
+    <h2>Giveaway</h2>
+  {/snippet}
+
+  {#snippet body()}
+    {@const generalErrorMessage = formatZodErrorMessage(
+      validtionErrors,
+      "sendChatMessage",
+    )}
+    {@const keywordErrorMessage = formatZodErrorMessage(
+      validtionErrors,
+      "keyword",
+    )}
+    {@const timeErrorMessage = formatZodErrorMessage(validtionErrors, "time")}
+    {@const subluckErrorMessage = formatZodErrorMessage(
+      validtionErrors,
+      "subluck",
+    )}
+
+    <div class="flex flex-col space-y-2">
+      <Label for="keyword">Keyword</Label>
+      <Input
+        type="text"
+        id="keyword"
+        placeholder="Enter giveaway keyword"
+        bind:value={keyword}
+      />
+      {#if keywordErrorMessage}
+        <p class="text-red-500 text-xs">{keywordErrorMessage}</p>
+      {/if}
+      <Label for="time">Time</Label>
+      <Input
+        type="number"
+        id="time"
+        placeholder="Enter time in minutes"
+        bind:value={time}
+      />
+      {#if timeErrorMessage}
+        <p class="text-red-500 text-xs">{timeErrorMessage}</p>
+      {/if}
+      <Label for="subluck">Subluck</Label>
+      <Input
+        type="number"
+        id="subluck"
+        placeholder="Enter subluck"
+        bind:value={subluck}
+      />
+      {#if subluckErrorMessage}
+        <p class="text-red-500 text-xs">{subluckErrorMessage}</p>
+      {/if}
+
+      <hr />
+
+      {#if generalErrorMessage}
+        <p class="text-red-500 text-xs">{generalErrorMessage}</p>
+      {/if}
+      <div class="flex justify-end space-x-2">
+        <Button variant="secondary" size="sm" class="w-full" onclick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          class="w-full"
+          onclick={onCreateGiveaway}>Create Giveaway</Button
+        >
+      </div>
+    </div>
+  {/snippet}
+</Modal>

--- a/src/lib/entryPoints/emoteMenuButton.ts
+++ b/src/lib/entryPoints/emoteMenuButton.ts
@@ -1,4 +1,4 @@
-import { mount } from "svelte";
+import { mount, unmount } from "svelte";
 import EmoteMenuButton from "../components/app/EmoteMenuButton.svelte";
 
 const attachedClass = "ftv-emotes-attached";
@@ -39,8 +39,7 @@ export async function emoteMenuButton(ctx: any, mutation: MutationRecord) {
       });
       return app;
     },
-    onRemove: (app) => {
-      // @ts-ignore https://svelte-5-preview.vercel.app/docs/breaking-changes
+    onRemove: (app: any) => {
       unmount(app);
     },
   });

--- a/src/lib/entryPoints/home/feedSuggestionsList.ts
+++ b/src/lib/entryPoints/home/feedSuggestionsList.ts
@@ -89,10 +89,10 @@ export async function feedSuggestionsList(ctx: any, mutation: MutationRecord) {
             startedAt: onlineCreator.streaming.channel.stream.startedAt,
           },
         });
+
         return app;
       },
-      onRemove: (app) => {
-        // @ts-ignore
+      onRemove: (app: any) => {
         unmount(app);
       },
     });

--- a/src/lib/entryPoints/uptime.ts
+++ b/src/lib/entryPoints/uptime.ts
@@ -1,4 +1,4 @@
-import { mount } from "svelte";
+import { mount, unmount } from "svelte";
 import Uptime from "../components/app/Uptime.svelte";
 
 const attachedClass = "ftv-uptime-attached";
@@ -33,8 +33,7 @@ export async function uptime(ctx: any, mutation: MutationRecord) {
 
       return app;
     },
-    onRemove: (app) => {
-      // @ts-ignore https://svelte-5-preview.vercel.app/docs/breaking-changes
+    onRemove: (app: any) => {
       unmount(app);
     },
   });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export enum ActionType {
   None = "none",
   Changelog = "changelog",
   ChatPoll = "chatPoll",
+  Giveaway = "giveaway",
 }
 
 export type FanslyResponse<T> = {


### PR DESCRIPTION
#31

- Introduced a new action type 'Giveaway' in ActionType enum.
- Updated ActionsButtonModal to include a button for starting a giveaway.
- Added GiveawayModal component to handle giveaway actions.
- Refactored onRemove functions in emoteMenuButton, uptime, and feedSuggestionsList to use explicit typing for app parameter.

This enhances user interaction by allowing giveaways alongside existing features like polls and changelogs.